### PR TITLE
Release 49 re:dash

### DIFF
--- a/release/49/stability-metrics-redash/README.md
+++ b/release/49/stability-metrics-redash/README.md
@@ -1,0 +1,9 @@
+Stability metrics relevant to the e10s add-ons experiment are monitored using a 
+re:dash dashboard
+<!--
+[re:dash dashboard](https://sql.telemetry.mozilla.org/dashboard/stability-comparison-for-e10s-add-ons-experiment)
+-->
+rather than in the notebooks.
+
+Code and visualizations details for the relevant queries are maintained in stability-metrics.yaml, synced with re:dash using [this tool](https://github.com/dzeber/fill-redash-from-source/tree/generate-yaml).
+

--- a/release/49/stability-metrics-redash/README.md
+++ b/release/49/stability-metrics-redash/README.md
@@ -1,9 +1,4 @@
-Stability metrics relevant to the e10s add-ons experiment are monitored using a 
-re:dash dashboard
-<!--
-[re:dash dashboard](https://sql.telemetry.mozilla.org/dashboard/stability-comparison-for-e10s-add-ons-experiment)
--->
-rather than in the notebooks.
+Stability metrics relevant to the e10s add-ons experiment are monitored using a [re:dash dashboard](https://sql.telemetry.mozilla.org/dashboard/stability-metrics-for-e10s-add-ons-experiment-release-49-) rather than in the notebooks.
 
 Code and visualizations details for the relevant queries are maintained in stability-metrics.yaml, synced with re:dash using [this tool](https://github.com/dzeber/fill-redash-from-source/tree/generate-yaml).
 

--- a/release/49/stability-metrics-redash/stability-metrics.yaml
+++ b/release/49/stability-metrics-redash/stability-metrics.yaml
@@ -1,8 +1,7 @@
 queries:
 - api_key: ac651fbb9ef43be31d0415548c3b3042828b0f88
   data_source: Presto
-  description: In Release 49, 100% of the eligible population should be placed in
-    the test cohorts (no control)
+  description: ''
   id: 1245
   name: Daily proportion of Release 49 usage in e10s cohorts
   query: |
@@ -91,9 +90,11 @@ queries:
       sortX: true
       xAxis:
         labels: {enabled: true}
+        title: {text: Activity date}
         type: datetime
       yAxis:
-      - {type: linear}
+      - title: {text: Percentage of usage hours}
+        type: linear
       - {opposite: true, type: linear}
     type: CHART
   - description: ''
@@ -111,9 +112,11 @@ queries:
       sortX: true
       xAxis:
         labels: {enabled: true}
+        title: {text: Activity date}
         type: datetime
       yAxis:
-      - {type: linear}
+      - title: {text: Usage hours}
+        type: linear
       - {opposite: true, type: linear}
     type: CHART
   - description: ''
@@ -131,9 +134,11 @@ queries:
       sortX: true
       xAxis:
         labels: {enabled: true}
+        title: {text: Activity date}
         type: datetime
       yAxis:
-      - {type: linear}
+      - title: {text: Usage hours}
+        type: linear
       - {opposite: true, type: linear}
     type: CHART
   - description: ''
@@ -150,15 +155,16 @@ queries:
       sortX: true
       xAxis:
         labels: {enabled: true}
+        title: {text: Activity date}
         type: datetime
       yAxis:
-      - {type: linear}
+      - title: {text: Percentage of usage hours}
+        type: linear
       - {opposite: true, type: linear}
     type: CHART
 - api_key: 198047a7c3d756b3dcc34a03d35c93818f89099b
   data_source: Presto
-  description: Comparison of crash rates between standard test and add-ons test cohort
-    (no control)
+  description: ''
   id: 1253
   name: E10s stability comparison by activity date (Release 49)
   query: |-

--- a/release/49/stability-metrics-redash/stability-metrics.yaml
+++ b/release/49/stability-metrics-redash/stability-metrics.yaml
@@ -155,3 +155,131 @@ queries:
       - {type: linear}
       - {opposite: true, type: linear}
     type: CHART
+- api_key: 198047a7c3d756b3dcc34a03d35c93818f89099b
+  data_source: Presto
+  description: Comparison of crash rates between standard test and add-ons test cohort
+    (no control)
+  id: 1253
+  name: E10s stability comparison by activity date (Release 49)
+  query: |-
+    WITH channel_data AS (
+      /* Restrict to population and dates of interest */
+      SELECT *
+      FROM crash_aggregates
+      WHERE
+      -- Dates start from the release of Release 49
+      submission_date >= '2016-09-20'
+      AND activity_date >= '2016-09-20'
+      -- Fx Release 49
+      AND dimensions['application'] = 'Firefox'
+      AND dimensions['channel'] = 'release'
+      AND dimensions['build_version'] like '49.%'
+      -- No active experiment
+      AND dimensions['experiment_id'] IS NULL
+      -- Test groups with and without add-ons
+      AND dimensions['e10s_cohort'] IN ('addons-set49a-test', 'test')
+    ),
+    crash_counts AS (
+      /* Total crashes and usage time by date and cohort */
+      SELECT
+      activity_date,
+      dimensions['e10s_cohort'] AS e10s_cohort,
+      -- Usage hours (in 1000s)
+      SUM(stats['usage_hours']) / 1000 AS usage_khours,
+      -- Total crashes for each type
+      SUM(stats['main_crashes']) AS main_crashes,
+      SUM(stats['content_crashes']) AS content_crashes,
+      SUM(stats['content_shutdown_crashes']) AS content_shutdown_crashes,
+      SUM(stats['plugin_crashes']) AS npapi_plugin_crashes,
+      SUM(stats['gmplugin_crashes']) AS media_plugin_crashes
+      FROM channel_data
+      GROUP BY 1, 2
+    ),
+    counts_over_time AS (
+      /* Base crash count dataset, excluding uninformative rows */
+      SELECT *
+      FROM crash_counts
+      WHERE usage_khours > 1
+    )
+    /* Compute crash rates for each crash type as well as combined */
+    SELECT
+    activity_date,
+    e10s_cohort,
+    main_crashes / usage_khours AS main_crash_rate,
+    (content_crashes - content_shutdown_crashes) / usage_khours AS content_crash_rate_noshutdown,
+    content_shutdown_crashes / usage_khours AS content_shutdown_crash_rate,
+    npapi_plugin_crashes / usage_khours AS npapi_plugin_crash_rate,
+    media_plugin_crashes / usage_khours AS media_plugin_crash_rate,
+    (main_crashes + content_crashes - content_shutdown_crashes) / usage_khours AS combined_app_crash_rate,
+    (npapi_plugin_crashes + media_plugin_crashes) / usage_khours AS combined_plugin_crash_rate
+    FROM counts_over_time
+    -- Drop the most recent days as data may be incomplete
+    WHERE CAST(activity_date AS date) < current_date - interval '2' day
+    ORDER BY activity_date, e10s_cohort ASC
+  schedule: '86400'
+  visualizations:
+  - description: ''
+    id: 2171
+    name: Combined app crash rate (main/content)
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, combined_app_crash_rate: y, combined_plugin_crash_rate: unused,
+        e10s_cohort: series, main_crash_rate: unused}
+      globalSeriesType: line
+      legend: {enabled: true}
+      series: {stacking: null}
+      seriesOptions:
+        test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        title: {text: Activity date}
+        type: datetime
+      yAxis:
+      - title: {text: Crashes per khour}
+        type: linear
+      - {opposite: true, type: linear}
+    type: CHART
+  - description: ''
+    id: 2170
+    name: Combined plugin crash rate
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, combined_app_crash_rate: unused, combined_plugin_crash_rate: y,
+        e10s_cohort: series, main_crash_rate: unused}
+      globalSeriesType: line
+      legend: {enabled: true}
+      series: {stacking: null}
+      seriesOptions:
+        test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        title: {text: Activity date}
+        type: datetime
+      yAxis:
+      - title: {text: Crashes per khour}
+        type: linear
+      - {opposite: true, type: linear}
+    type: CHART
+  - description: ''
+    id: 2169
+    name: Main crash rate
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, e10s_cohort: series, main_crash_rate: y}
+      globalSeriesType: line
+      legend: {enabled: true}
+      series: {stacking: normal}
+      seriesOptions:
+        test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        title: {text: Activity date}
+        type: datetime
+      yAxis:
+      - title: {text: Crashes per khour}
+        type: linear
+      - {opposite: true, type: linear}
+    type: CHART

--- a/release/49/stability-metrics-redash/stability-metrics.yaml
+++ b/release/49/stability-metrics-redash/stability-metrics.yaml
@@ -70,7 +70,7 @@ queries:
     FROM usage_props
     WHERE
     -- Drop the most recent days as data may be incomplete
-    CAST(activity_date AS date) < current_date - interval '2' day
+    CAST(activity_date AS date) < current_date - interval '1' day
     GROUP BY 1
     ORDER BY 1
   schedule: '86400'
@@ -220,7 +220,7 @@ queries:
     (npapi_plugin_crashes + media_plugin_crashes) / usage_khours AS combined_plugin_crash_rate
     FROM counts_over_time
     -- Drop the most recent days as data may be incomplete
-    WHERE CAST(activity_date AS date) < current_date - interval '2' day
+    WHERE CAST(activity_date AS date) < current_date - interval '1' day
     ORDER BY activity_date, e10s_cohort ASC
   schedule: '86400'
   visualizations:

--- a/release/49/stability-metrics-redash/stability-metrics.yaml
+++ b/release/49/stability-metrics-redash/stability-metrics.yaml
@@ -235,6 +235,8 @@ queries:
       legend: {enabled: true}
       series: {stacking: null}
       seriesOptions:
+        addons-set49a-test: {index: 0, name: E10s with add-ons, type: line, yAxis: 0,
+          zIndex: 1}
         test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
       sortX: true
       xAxis:
@@ -257,6 +259,8 @@ queries:
       legend: {enabled: true}
       series: {stacking: null}
       seriesOptions:
+        addons-set49a-test: {index: 0, name: E10s with add-ons, type: line, yAxis: 0,
+          zIndex: 1}
         test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
       sortX: true
       xAxis:
@@ -278,6 +282,8 @@ queries:
       legend: {enabled: true}
       series: {stacking: normal}
       seriesOptions:
+        addons-set49a-test: {index: 0, name: E10s with add-ons, type: line, yAxis: 0,
+          zIndex: 1}
         test: {index: 0, name: E10s (no add-ons), type: line, yAxis: 0, zIndex: 0}
       sortX: true
       xAxis:

--- a/release/49/stability-metrics-redash/stability-metrics.yaml
+++ b/release/49/stability-metrics-redash/stability-metrics.yaml
@@ -1,0 +1,157 @@
+queries:
+- api_key: ac651fbb9ef43be31d0415548c3b3042828b0f88
+  data_source: Presto
+  description: In Release 49, 100% of the eligible population should be placed in
+    the test cohorts (no control)
+  id: 1245
+  name: Daily proportion of Release 49 usage in e10s cohorts
+  query: |
+    WITH channel_data AS (
+      /* Restrict to population and dates of interest */
+      SELECT *
+      FROM crash_aggregates
+      WHERE
+      -- Dates start from the release of Release 49
+      submission_date >= '2016-09-20'
+      AND activity_date >= '2016-09-20'
+      -- Fx Release 49
+      AND dimensions['application'] = 'Firefox'
+      AND dimensions['channel'] = 'release'
+      AND dimensions['build_version'] like '49.%'
+      -- No active experiment
+      AND dimensions['experiment_id'] IS NULL
+    ),
+    usage_by_cohort_and_date AS (
+      /* Total usage hours by activity date and cohort */
+      SELECT
+      activity_date,
+      dimensions['e10s_cohort'] AS e10s_cohort,
+      SUM(stats['usage_hours']) AS usage_hours
+      FROM channel_data
+      GROUP BY 1, 2
+    ),
+    usage_by_date AS (
+      /* Total usage hours by date only */
+      SELECT
+      activity_date,
+      SUM(usage_hours) AS total_usage_hours
+      FROM usage_by_cohort_and_date
+      GROUP BY 1
+    ),
+    usage_by_cohort_with_totals AS (
+      SELECT
+      ubcad.*,
+      total_usage_hours
+      FROM usage_by_cohort_and_date AS ubcad
+      JOIN usage_by_date AS ubd
+        ON ubcad.activity_date = ubd.activity_date
+    ),
+    /* Proportion of usage by cohort and date */
+    usage_props AS (
+      SELECT
+      activity_date,
+      e10s_cohort,
+      usage_hours,
+      usage_hours / total_usage_hours as usage_prop
+      FROM usage_by_cohort_with_totals
+    )
+    /* Total usage hours and proportions for cohorts with and without add-ons.
+     * Note that there is no control group in Release 49.
+     */
+    SELECT
+    activity_date,
+    SUM(CASE WHEN e10s_cohort = 'addons-set49a-test' THEN usage_hours ELSE 0 END)
+      AS usage_hours_addons,
+    SUM(CASE WHEN e10s_cohort = 'addons-set49a-test' THEN usage_prop ELSE 0 END) * 100
+      AS usage_pct_addons,
+    SUM(CASE WHEN e10s_cohort = 'test' THEN usage_hours ELSE 0 END)
+      AS usage_hours_std,
+    SUM(CASE WHEN e10s_cohort = 'test' THEN usage_prop ELSE 0 END) * 100
+      AS usage_pct_std
+    FROM usage_props
+    WHERE
+    -- Drop the most recent days as data may be incomplete
+    CAST(activity_date AS date) < current_date - interval '2' day
+    GROUP BY 1
+    ORDER BY 1
+  schedule: '86400'
+  visualizations:
+  - description: ''
+    id: 2159
+    name: Daily percentage of e10s cohort usage from add-ons test cohort
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, usage_hours_addons: unused, usage_hours_std: unused,
+        usage_pct_addons: y, usage_pct_std: unused}
+      globalSeriesType: line
+      legend: {enabled: false}
+      series: {stacking: null}
+      seriesOptions:
+        usage_pct_addons: {index: 0, type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        type: datetime
+      yAxis:
+      - {type: linear}
+      - {opposite: true, type: linear}
+    type: CHART
+  - description: ''
+    id: 2158
+    name: Daily usage hours for profiles in the e10s add-ons test cohort
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, usage_hours_addons: y, usage_hours_std: unused,
+        usage_pct_std: unused}
+      globalSeriesType: line
+      legend: {enabled: false}
+      series: {stacking: null}
+      seriesOptions:
+        usage_hours_addons: {index: 0, type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        type: datetime
+      yAxis:
+      - {type: linear}
+      - {opposite: true, type: linear}
+    type: CHART
+  - description: ''
+    id: 2157
+    name: Daily usage hours for profiles in the e10s standard test cohort
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, usage_hours_addons: unused, usage_hours_std: y,
+        usage_pct_std: unused}
+      globalSeriesType: line
+      legend: {enabled: false}
+      series: {stacking: null}
+      seriesOptions:
+        usage_hours_std: {index: 0, type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        type: datetime
+      yAxis:
+      - {type: linear}
+      - {opposite: true, type: linear}
+    type: CHART
+  - description: ''
+    id: 2156
+    name: Daily percentage of e10s cohort usage from the standard test cohort
+    options:
+      bottomMargin: 50
+      columnMapping: {activity_date: x, usage_hours_addons: unused, usage_pct_std: y}
+      globalSeriesType: line
+      legend: {enabled: false}
+      series: {stacking: null}
+      seriesOptions:
+        usage_pct_std: {index: 0, type: line, yAxis: 0, zIndex: 0}
+      sortX: true
+      xAxis:
+        labels: {enabled: true}
+        type: datetime
+      yAxis:
+      - {type: linear}
+      - {opposite: true, type: linear}
+    type: CHART


### PR DESCRIPTION
Adding the spec for the re:dash stability dashboard we are using for tracking e10s with add-ons in Release 49.